### PR TITLE
bugfix: fix iOS 26.2 message handler issues

### DIFF
--- a/Sources/aerosync-ios-sdk/aerosync_ios_sdk.swift
+++ b/Sources/aerosync-ios-sdk/aerosync_ios_sdk.swift
@@ -63,7 +63,7 @@ public struct AerosyncSDK: UIViewRepresentable{
         webView.configuration.userContentController.add(coordinator, name: "onEvent")
         webView.configuration.userContentController.add(coordinator, name: "onError")
         webView.configuration.userContentController.add(coordinator, name: "onSuccess")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onBankClick")
+        webView.configuration.userContentController.add(coordinator, name: "onBankClick")
 
         coordinator.webView = webView
 

--- a/Sources/aerosync-ios-sdk/aerosync_ios_sdk.swift
+++ b/Sources/aerosync-ios-sdk/aerosync_ios_sdk.swift
@@ -63,6 +63,7 @@ public struct AerosyncSDK: UIViewRepresentable{
         webView.configuration.userContentController.add(coordinator, name: "onEvent")
         webView.configuration.userContentController.add(coordinator, name: "onError")
         webView.configuration.userContentController.add(coordinator, name: "onSuccess")
+        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onBankClick")
 
         coordinator.webView = webView
 

--- a/Sources/aerosync-ios-sdk/aerosync_ios_sdk.swift
+++ b/Sources/aerosync-ios-sdk/aerosync_ios_sdk.swift
@@ -56,20 +56,15 @@ public struct AerosyncSDK: UIViewRepresentable{
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
-        // inject JS to capture console.log output and send to iOS
-        let source = "function captureLog(msg) { window.webkit.messageHandlers.logHandler.postMessage(msg); } window.console.log = captureLog;"
-        let script = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-        webView.configuration.userContentController.addUserScript(script)
-        
-        // register the bridge script that listens for the output
+        // Use context.coordinator instead of creating new instances
+        let coordinator = context.coordinator
         webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onClose")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "logHandler")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onEvent")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onError")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onSuccess")
-        webView.configuration.userContentController.add(Coordinator(wrapper: self), name: "onBankClick")
-        context.coordinator.webView = webView
+        webView.configuration.userContentController.add(coordinator, name: "onClose")
+        webView.configuration.userContentController.add(coordinator, name: "onEvent")
+        webView.configuration.userContentController.add(coordinator, name: "onError")
+        webView.configuration.userContentController.add(coordinator, name: "onSuccess")
+
+        coordinator.webView = webView
 
         // SETUP GESTURE RECOGNIZER
         let gestureRecognizerBack = UISwipeGestureRecognizer(target: context.coordinator, action: #selector(context.coordinator.handleBack))
@@ -202,6 +197,7 @@ public struct AerosyncSDK: UIViewRepresentable{
         public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             wrapper.onLoad("\(webView.url!)")
             let triggerEventScript = """
+                window.iOSReady = true;
                 var event = new CustomEvent('iOSReady', { detail: 'iOS Ready' });
                 window.dispatchEvent(event);
             """


### PR DESCRIPTION
## Changes
- Use context.coordinator instead of creating new Coordinator instances
- Set window.iOSReady flag to prevent race condition with new WebContent processes
- Remove unused logHandler console.log interception

## Testing:

Test Environment Setup
iOS 26.2+: iPhone 14/15 simulator or device with iOS 26.2
iOS < 26.2: iPhone 14 simulator with iOS 18.0 (or latest pre-26.2 version)
Test App: test-sync-ios-sdk app

- Load the Aerosync widget
- All events (onSuccess, onEvent, onClose) should fire in logs
- Modal dismisses properly for onClose and OnSuccess event
- Test if the continue button in the final success page triggers onSucces event

Pass Criteria
- All events fire correctly
- Modal dismisses properly
- Continue button triggers onSuccess
- Works on multiple runs without app restart
- No crashes